### PR TITLE
Add asset existence test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # unofficalwebsite
+
+To run the tests, execute:
+
+```bash
+python -m unittest
+```

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1,0 +1,22 @@
+import unittest
+import re
+from pathlib import Path
+
+
+class TestAssets(unittest.TestCase):
+    def test_local_src_files_exist(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        html_path = repo_root / "index.html"
+        html = html_path.read_text(encoding="utf-8")
+        src_values = re.findall(r'src="([^"]+)"', html)
+        self.assertTrue(src_values, "No src attributes found in index.html")
+
+        for src in src_values:
+            if src.startswith("http://") or src.startswith("https://"):
+                continue
+            asset_path = repo_root / src
+            self.assertTrue(asset_path.exists(), f"Missing asset: {src}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `tests` directory with `test_assets.py`
- verify that local paths from `index.html` actually exist
- document running tests with `python -m unittest`

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_6845a38ae958832a895187d82f65b979